### PR TITLE
fix: move db seeding and admin user creation to setup script

### DIFF
--- a/bin/install-docker
+++ b/bin/install-docker
@@ -5,9 +5,7 @@ current_directory="$PWD"
 
 cd $(dirname $0)/..
 
-#docker cp PublicSquare publicsquare-magento-payments-plugin-app-1:/var/www/html/app/code/
-bin/magento sampledata:deploy
-bin/magento admin:user:create --admin-user=admin --admin-password=AdminPassword123 --admin-email=admin@example.com --admin-firstname=admin --admin-lastname=admin
+docker cp PublicSquare publicsquare-magento-payments-plugin-app-1:/var/www/html/app/code/
 
 echo "ADDITIONAL INSTALLATION INSTRUCTIONS:"
 

--- a/bin/setup
+++ b/bin/setup
@@ -62,5 +62,7 @@ bin/clinotty bin/magento deploy:mode:set developer
 bin/cli bin/magento sampledata:deploy
 bin/clinotty bin/magento admin:user:create --admin-user=admin --admin-password=AdminPassword123 --admin-email=admin@example.com --admin-firstname=admin --admin-lastname=admin
 
+bin/clinotty bin/magento setup:upgrade
+
 echo "Docker development environment setup complete."
 echo "You may now access your Magento instance at https://${DOMAIN}/"

--- a/bin/setup
+++ b/bin/setup
@@ -14,12 +14,15 @@ bin/start --no-dev
 [ $? != 0 ] && echo "Failed to start Docker services" && exit
 
 bin/clinotty chmod u+x bin/magento
-rm -rf src/magento-site && mkdir src/magento-site
+rm -rf src/magento-site && mkdir -p src/magento-site
 
 echo "Adding Magento modules to Composer allow-plugins directive..."
 bin/clinotty composer config --no-plugins allow-plugins.magento/magento-composer-installer true
 bin/clinotty composer config --no-plugins allow-plugins.magento/inventory-composer-installer true
 bin/clinotty composer config --no-plugins allow-plugins.laminas/laminas-dependency-plugin true
+
+echo "Uninstalling Magento..."
+bin/clinotty bin/magento setup:uninstall -y
 
 echo "Running, Magento setup:install..."
 bin/setup-install "${DOMAIN}"
@@ -55,6 +58,9 @@ bin/clinotty bin/magento cache:flush
 
 echo "Turning on developer mode..."
 bin/clinotty bin/magento deploy:mode:set developer
+
+bin/clinotty bin/magento sampledata:deploy
+bin/clinotty bin/magento admin:user:create --admin-user=admin --admin-password=AdminPassword123 --admin-email=admin@example.com --admin-firstname=admin --admin-lastname=admin
 
 echo "Docker development environment setup complete."
 echo "You may now access your Magento instance at https://${DOMAIN}/"

--- a/bin/setup
+++ b/bin/setup
@@ -22,7 +22,7 @@ bin/clinotty composer config --no-plugins allow-plugins.magento/inventory-compos
 bin/clinotty composer config --no-plugins allow-plugins.laminas/laminas-dependency-plugin true
 
 echo "Uninstalling Magento..."
-bin/clinotty bin/magento setup:uninstall -y
+bin/clinotty bin/magento setup:uninstall -n
 
 echo "Running, Magento setup:install..."
 bin/setup-install "${DOMAIN}"
@@ -59,7 +59,7 @@ bin/clinotty bin/magento cache:flush
 echo "Turning on developer mode..."
 bin/clinotty bin/magento deploy:mode:set developer
 
-bin/clinotty bin/magento sampledata:deploy
+bin/cli bin/magento sampledata:deploy
 bin/clinotty bin/magento admin:user:create --admin-user=admin --admin-password=AdminPassword123 --admin-email=admin@example.com --admin-firstname=admin --admin-lastname=admin
 
 echo "Docker development environment setup complete."


### PR DESCRIPTION
`make install-docker` will be deprecated now that we're leaning on volume from Docker automatically.

Therefore, db seeding and admin user creation should be done at setup. I also was encountering an error yesterday on a fresh build where the setup script failed during installation, and I had to uninstall Magento before it would pass again.