### PR TITLE
fix: bug where shipping address is wrong after placeOrder

### DIFF
--- a/PublicSquare/Payments/Model/Api/Payments.php
+++ b/PublicSquare/Payments/Model/Api/Payments.php
@@ -191,8 +191,7 @@ class Payments implements PaymentsInterface
             throw new \Magento\Framework\Exception\CouldNotSaveException(__('!$cardId && !$publicHash'.self::ERROR_MESSAGE));
         }
 
-        $quoteId = $this->checkoutSession->getQuoteId();
-        $quote = $this->quoteFactory->create()->load($quoteId);
+        $quote = $this->checkoutSession->getQuote();
         $billingAddress = $quote->getBillingAddress();
         $shippingAddress = $quote->getShippingAddress();
         $phoneNumber = $billingAddress->getTelephone();
@@ -216,7 +215,7 @@ class Payments implements PaymentsInterface
             }
         }
         if ($customer) {
-            $quote->assignCustomer($customer);
+            $quote->setCustomer($customer);
         }
 
         $phoneNumber = str_replace(" ", "-", $phoneNumber);

--- a/PublicSquare/Payments/Model/Api/Payments.php
+++ b/PublicSquare/Payments/Model/Api/Payments.php
@@ -20,7 +20,6 @@ use Magento\Quote\Api\CartManagementInterface;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Customer\Model\CustomerFactory;
-use Magento\Quote\Model\QuoteFactory;
 use PublicSquare\Payments\Helper\Config;
 use Magento\Sales\Model\Service\InvoiceService;
 use Magento\Sales\Api\OrderRepositoryInterface;
@@ -71,11 +70,6 @@ class Payments implements PaymentsInterface
      * @var CustomerFactory
      */
     protected $customerFactory;
-
-    /**
-     * @var QuoteFactory
-     */
-    protected $quoteFactory;
 
     /**
      * @var Config
@@ -145,7 +139,6 @@ class Payments implements PaymentsInterface
         CustomerRepositoryInterface $customerRepository,
         StoreManagerInterface $storeManager,
         CustomerFactory $customerFactory,
-        QuoteFactory $quoteFactory,
         Config $configHelper,
         InvoiceService $invoiceService,
         OrderRepositoryInterface $orderRepository,
@@ -164,7 +157,6 @@ class Payments implements PaymentsInterface
         $this->customerRepository = $customerRepository;
         $this->storeManager = $storeManager;
         $this->customerFactory = $customerFactory;
-        $this->quoteFactory = $quoteFactory;
         $this->configHelper = $configHelper;
         $this->invoiceService = $invoiceService;
         $this->orderRepository = $orderRepository;

--- a/PublicSquare/Payments/composer.json
+++ b/PublicSquare/Payments/composer.json
@@ -2,7 +2,7 @@
   "name": "publicsquare/module-payments",
   "description": "PublicSquare provides a software platform for retailers to access third-party providers for lease-to-own financing and other lending products based on a consumer credit profile.",
   "type": "magento2-module",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
There is a bug where if you have a different shipping address from the billing address on your account, the order is placed using the billing address (or default address). This was due to some "magic" happening behind the scenes when calling `$quote->assignCustomer($customer)`. Whereas `setCustomer` seems to behave a lot better.

Also, a small optimization is included to just grab the quote object from `checkoutSession` instead of using `quoteFactory`.