### PR TITLE
feat: add setting to control whether we lookup existing customer account by email

### DIFF
--- a/PublicSquare/Payments/Helper/Config.php
+++ b/PublicSquare/Payments/Helper/Config.php
@@ -33,7 +33,7 @@ class Config extends AbstractHelper
     const PUBLICSQUARE_PAYMENT_ACTION                       = 'payment/publicsquare_payments/payment_action';
     const PUBLICSQUARE_LOGGING_CONFIG_PATH                  = 'payment/publicsquare_payments/debug';
     const PUBLICSQUARE_CARD_IMAGES_BASE_PATH                = 'https://assets.publicsquare.com/sc/web/assets/images/cards/';
-    
+    const PUBLICSQUARE_CUSTOMER_LOOKUP                       = 'payment/publicsquare_payments/customer_lookup';
     /**
      * @var \Magento\Framework\Serialize\Serializer\Json
      */
@@ -142,6 +142,21 @@ class Config extends AbstractHelper
         return (bool) $this->scopeConfig
             ->getValue(self::PUBLICSQUARE_LOGGING_CONFIG_PATH, $scopeType, $scopeCode);
     } //end getPublicSquareLoggingEnabled()
+
+    /**
+     * Get setting for customer lookup during checkout
+     *
+     * @param  string $scopeType
+     * @param  null   $scopeCode
+     * @return boolean
+     */
+    public function getGuestCheckoutCustomerLookup(
+        $scopeType = \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+        $scopeCode = null
+    ): bool {
+        return (bool) $this->scopeConfig
+            ->getValue(self::PUBLICSQUARE_CUSTOMER_LOOKUP, $scopeType, $scopeCode);
+    } //end getGuestCheckoutCustomerLookup()
 
     /**
      * Get publicsquare payment capture action

--- a/PublicSquare/Payments/etc/adminhtml/system.xml
+++ b/PublicSquare/Payments/etc/adminhtml/system.xml
@@ -74,6 +74,11 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                     <config_path>payment/publicsquare_payments_cc_vault/active</config_path>
                 </field>
+                <field id="customer_lookup" translate="label" type="select" sortOrder="19" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Guest Checkout Customer Lookup</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <comment><![CDATA[Whether to lookup an existing customer by email address and assign them to the order if found.]]></comment>
+                </field>
             </group>
         </section>
     </system>

--- a/PublicSquare/Payments/etc/config.xml
+++ b/PublicSquare/Payments/etc/config.xml
@@ -25,6 +25,7 @@
                 <card_types>amex,visa,mastercard,discover</card_types>
                 <payment_action>sale</payment_action>
                 <avs_check>1</avs_check>
+                <customer_lookup>1</customer_lookup>
                 <!-- What can we do? -->
                 <is_gateway>1</is_gateway>
                 <can_authorize>1</can_authorize>


### PR DESCRIPTION
Add a setting in the plugin config to control whether we do an email lookup for an existing customer.

This is the line where we lookup an existing customer by email: https://github.com/publicsquare-financial/publicsquare-magento-payments-plugin/blob/dd2b06279ba05dba1dd57d49645bff049c6577df/PublicSquare/Payments/Model/Api/Payments.php#L204

Acceptance criteria:

1. Customer is only looked up and connected to order if setting is true

![Screenshot 2024-10-22 at 12 53 57 PM](https://github.com/user-attachments/assets/80dec06d-6e5b-459a-b1c4-6560efc03600)
