### PR TITLE
fix: implicit conversion error for $amount

### DIFF
--- a/PublicSquare/Payments/Api/Authenticated/Payments.php
+++ b/PublicSquare/Payments/Api/Authenticated/Payments.php
@@ -30,7 +30,7 @@ class Payments extends PublicSquareAPIRequestAbstract
         \Laminas\Http\ClientFactory $clientFactory,
         \PublicSquare\Payments\Helper\Config $configHelper,
         \PublicSquare\Payments\Logger\Logger $logger,
-        int $amount,
+        float $amount,
         string $cardId,
         bool $capture,
         string $phone,
@@ -40,7 +40,7 @@ class Payments extends PublicSquareAPIRequestAbstract
     ) {
         parent::__construct($clientFactory, $configHelper, $logger);
         $this->requestData = [
-            "amount" => $amount,
+            "amount" => (int)($amount * 100),
             "currency" => "USD",
             // Authorize only, because the CaptureCommand will handle capturing the payment
             "capture" => $capture,

--- a/PublicSquare/Payments/Model/Api/Payments.php
+++ b/PublicSquare/Payments/Model/Api/Payments.php
@@ -264,7 +264,7 @@ class Payments implements PaymentsInterface
             @var \PublicSquare\Payments\Api\Authenticated\Payments $request
              */
             $request = $this->paymentsRequestFactory->create([
-                "amount" => $quote->getGrandTotal() * 100,
+                "amount" => $quote->getGrandTotal(),
                 "cardId" => $cardId,
                 "capture" => false,
                 "phone" => $billingAddress->getTelephone(),

--- a/PublicSquare/Payments/composer.json
+++ b/PublicSquare/Payments/composer.json
@@ -2,7 +2,7 @@
   "name": "publicsquare/module-payments",
   "description": "PublicSquare provides a software platform for retailers to access third-party providers for lease-to-own financing and other lending products based on a consumer credit profile.",
   "type": "magento2-module",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
1. Fix PHP 8.1 error for implicit conversion from float to int that was reported

https://wiki.php.net/rfc/implicit-float-int-deprecate