### PR TITLE
Fixed type and order of arguments for shipping address

### DIFF
--- a/PublicSquare/Payments/Api/Authenticated/Payments.php
+++ b/PublicSquare/Payments/Api/Authenticated/Payments.php
@@ -35,8 +35,8 @@ class Payments extends PublicSquareAPIRequestAbstract
         bool $capture,
         string $phone,
         string $email,
-        \Magento\Quote\Model\Quote\Address $shippingAddress = null,
-        \Magento\Quote\Model\Quote\Address $billingAddress
+        \Magento\Quote\Model\Quote\Address $billingAddress,
+        $shippingAddress = null
     ) {
         parent::__construct($clientFactory, $configHelper, $logger);
         $this->requestData = [


### PR DESCRIPTION
This resolved two issues only present when running in production mode: 

1. The $shippingAddress was forced to be of type \Magento\Quote\Model\Quote\Address. So when this object was instantiated, it created an empty address object. (Not null)
2. Any optional parameters need to be last when declaring arguments.