### PR TITLE
fix: dont run validation for non psq payment methods

### DIFF
--- a/PublicSquare/Payments/Gateway/PaymentExecutor.php
+++ b/PublicSquare/Payments/Gateway/PaymentExecutor.php
@@ -415,6 +415,44 @@ class PaymentExecutor
 			\Magento\Sales\Model\Order\Payment\Transaction::RAW_DETAILS,
 			$response
 		);
+		if (array_key_exists("fraud_details", $response)) {
+			if (
+				array_key_exists("decision", $response["fraud_details"])
+			) {
+				$payment->setAdditionalInformation(
+					"fraud_decision",
+					$response["fraud_details"]["decision"]
+				);
+			}
+			if (array_key_exists("rules", $response["fraud_details"])) {
+				$payment->setAdditionalInformation(
+					"fraud_rules",
+					$response["fraud_details"]["rules"]
+				);
+			}
+		}
+		if (
+			array_key_exists(
+				"avs_code",
+				$response["payment_method"]["card"]
+			)
+		) {
+			$payment->setAdditionalInformation(
+				"avsCode",
+				$response["payment_method"]["card"]["avs_code"]
+			);
+		}
+		if (
+			array_key_exists(
+				"cvv2_reply",
+				$response["payment_method"]["card"]
+			)
+		) {
+			$payment->setAdditionalInformation(
+				"cvv2Reply",
+				$response["payment_method"]["card"]["cvv2_reply"]
+			);
+		}
 		$payment->setLastTransId($response["id"]);
 		$payment->setTransactionId($response["id"]);
 		$payment->setIsTransactionClosed($response["status"] == \PublicSquare\Payments\Api\ApiRequestAbstract::REQUIRES_CAPTURE_STATUS ? 0 : 1);

--- a/PublicSquare/Payments/composer.json
+++ b/PublicSquare/Payments/composer.json
@@ -2,7 +2,7 @@
   "name": "publicsquare/module-payments",
   "description": "PublicSquare provides a software platform for retailers to access third-party providers for lease-to-own financing and other lending products based on a consumer credit profile.",
   "type": "magento2-module",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": [
     "OSL-3.0",
     "AFL-3.0"

--- a/PublicSquare/Payments/view/adminhtml/web/js/publicsquare_admin.js
+++ b/PublicSquare/Payments/view/adminhtml/web/js/publicsquare_admin.js
@@ -9,7 +9,6 @@ define(
       lastNameSelector = '#order-billing_address_lastname',
       elementsFormSelector = '#publicsquare-elements-form',
       paymentMethodNonceSelector = '#publicsquare_payments_payment_method_nonce',
-      paymentsFormSelector = '#payment_form_publicsquare_payments',
       element = $(elementsFormSelector),
       originalOrderSubmit;
 
@@ -38,11 +37,15 @@ define(
     }
 
     function enableSubmitHandler() {
-      if (!window.order || !window.order.submit || window.order.paymentMethod !== 'publicsquare_payments') return;
+      if (!window.order || !window.order.submit) return;
       if (!originalOrderSubmit) {
         originalOrderSubmit = window.order.submit;
       }
-      window.order.submit = onSubmit;
+      if (window.order.paymentMethod === 'publicsquare_payments') {
+        window.order.submit = onSubmit;
+      } else if (originalOrderSubmit) {
+        window.order.submit = originalOrderSubmit;
+      }
     }
 
     function observe() {
@@ -68,13 +71,13 @@ define(
           }, () => {
             observe();
           })
-          enableSubmitHandler();
         })
       }
+      enableSubmitHandler();
     }
 
     const observer = new MutationObserver((mutations) => {
-      if (mutations.find((cur) => $(cur.target).find(paymentsFormSelector).length)) {
+      if (mutations.find((cur) => $(cur.target).is($('.payment-method') || $(cur.target).has('.payment-method')))) {
         renderElements();
       }
     });

--- a/PublicSquare/Payments/view/adminhtml/web/js/publicsquare_admin.js
+++ b/PublicSquare/Payments/view/adminhtml/web/js/publicsquare_admin.js
@@ -38,7 +38,7 @@ define(
     }
 
     function enableSubmitHandler() {
-      if (!window.order || !window.order.submit) return;
+      if (!window.order || !window.order.submit || window.order.paymentMethod !== 'publicsquare_payments') return;
       if (!originalOrderSubmit) {
         originalOrderSubmit = window.order.submit;
       }
@@ -68,9 +68,9 @@ define(
           }, () => {
             observe();
           })
+          enableSubmitHandler();
         })
       }
-      enableSubmitHandler();
     }
 
     const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
1. Fix case where card validation is triggered for non PSQ payment methods
2. Add the following fields to `sales_order_payment.additional_information`:
    1. `fraud_decision`
    2. `avsCode`
    3. `cvv2Reply`