### PR TITLE
chore: Remove union type on webhook controller

### DIFF
--- a/PublicSquare/Payments/Controller/Webhook/Index.php
+++ b/PublicSquare/Payments/Controller/Webhook/Index.php
@@ -7,6 +7,7 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\CsrfAwareActionInterface;
 use Magento\Framework\App\Request\InvalidRequestException;
 use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
 use Magento\Framework\Notification\NotifierInterface;
@@ -63,7 +64,7 @@ class Index implements HttpPostActionInterface, CsrfAwareActionInterface
         $this->collectionFactory = $collectionFactory;
     }
 
-    public function execute(): \Magento\Framework\Controller\Result\Json|\Magento\Framework\Controller\ResultInterface|\Magento\Framework\App\ResponseInterface
+    public function execute(): Json
     {
         $result = $this->jsonResultFactory->create();
         try {

--- a/PublicSquare/Payments/composer.json
+++ b/PublicSquare/Payments/composer.json
@@ -2,7 +2,7 @@
   "name": "publicsquare/module-payments",
   "description": "PublicSquare provides a software platform for retailers to access third-party providers for lease-to-own financing and other lending products based on a consumer credit profile.",
   "type": "magento2-module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": [
     "OSL-3.0",
     "AFL-3.0"


### PR DESCRIPTION
## Related Issue(s)

<!-- Link related issues below. -->

## Ticket type

- [ ] Feature
- [x] Bug
- [ ] Spike
- [x] Chore
- [ ] Documentation

## Change Types

- Frontend
    - [ ] UI/UX
    - [ ] Business Logic
- Backend
    - [ ] API Interface
        - [ ] Requests Changes
        - [ ] Response Changes
    - [ ] Business Logic
    - [ ] Database
- [ ] Observability

## Summary

Issues were reported in Adobe Commerce that the union type on the Webhook controller was causing issues. This change
removes the union type leaving just the response Json type.

## Dependencies

[Add requirements.]

## Checklist

- [x] Coding style
- [x] Self-review
- [x] Code comments
- [x] Docs
- [x] Local testing
- [x] Tests pass
- [ ] Added relevant tests
- [x] Logging & Observability

